### PR TITLE
Vertically center Appbar title

### DIFF
--- a/resources/js/components/Appbar.vue
+++ b/resources/js/components/Appbar.vue
@@ -6,7 +6,7 @@
                     <svg-vue class="w-6 cursor-pointer" icon="remix/menu-line" />
                 </button>
             </div>
-            <div class="flex-1 mb-0 my-auto text-center">
+            <div class="flex-1 my-auto text-center">
                 <span class="text-gray-800 font-medium text-xl">{{ title }}</span>
             </div>
             <div v-if="permission >= 6">


### PR DESCRIPTION
On smaller devices, the title within the Appbar is not centerd:
![image](https://user-images.githubusercontent.com/1368405/212928375-0f963dee-781c-4376-8b42-c891d09e5412.png)

This PR removes the `margin-bottom: 0` from the title, so it is vertically centerd again:
![image](https://user-images.githubusercontent.com/1368405/212928526-f6adae19-fe41-4123-9275-f39ef4f13c2d.png)
